### PR TITLE
fix: add router links to navigation in header whithout collapsed menu

### DIFF
--- a/src/components/header/navigation.tsx
+++ b/src/components/header/navigation.tsx
@@ -37,7 +37,9 @@ const Sections: FC = () => {
   return (
     <Stack direction={'row'}>
       {sectionsLabels.map((label) => (
-        <Button key={label}>{label}</Button>
+        <Button component={RouterLink} key={label} to={label}>
+          {label}
+        </Button>
       ))}
     </Stack>
   );


### PR DESCRIPTION
!!! **Pay attention, that we don't merge pull-requests without team members approval** !!!

## Proposed changes

- Describe the big picture of your changes here:
Add links in navigation menu, before links to sections work only in collapsed menu
## Types of changes

What types of changes does your code introduce to eCommerce-application?

<!-- _Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added necessary documentation (if appropriate)

## Related tickets & documents

- Link to the ticket: [ECA-102](https://ramankandratchyk.youtrack.cloud/issue/ECA-102/Make-header-adptive-add-burger-menu)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
